### PR TITLE
Dev environment setup: AGENTS.md + SwiftLint on Linux

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Platform reality: this is an iOS-only project on a Linux VM
+
+OSGKeyboard is a native **iOS 18+** app (main app + custom keyboard extension + shared
+framework, all Swift 6 / SwiftUI). The Cursor Cloud VM is **Linux x86_64**. iOS development
+is fundamentally macOS-only, so the following **cannot run in this environment**:
+
+- **Build** — needs `xcodebuild` + the iOS SDK (Xcode, macOS only).
+- **Run** — needs the iOS Simulator or a physical iPhone (macOS only).
+- **Tests** — `OSGKeyboardTests` / `OSGKeyboardExtTests` run via `xcodebuild test` against the
+  iOS Simulator (macOS only).
+
+Nearly every source file imports iOS-only frameworks (`SwiftUI`, `UIKit`, `AVFoundation`,
+`Speech`, `Combine`), so there is no meaningful subset that compiles with Swift-for-Linux.
+Do **not** attempt to build/run/test on the Linux VM — escalate to a macOS host with Xcode 16+
+(see `README.md` / `CONTRIBUTING.md` for the `xcodegen generate` + `xcodebuild` flow).
+
+### What *does* work on Linux: SwiftLint
+
+`swiftlint` (the `swiftlint-static` Linux binary, installed to `/usr/local/bin` by the update
+script) runs here because its rules are SwiftSyntax/source-based. Run it from the repo root:
+
+```bash
+swiftlint lint --quiet            # used by CI
+swiftlint lint --quiet --strict   # used by CI; promotes warnings to errors
+```
+
+Caveats:
+- On Linux, SourceKit is unavailable, so SourceKit-only rules are **skipped** (e.g. you will see
+  `Skipping enabled rule 'statement_position' because it requires SourceKit`). Lint results can
+  therefore differ slightly from a macOS run. Treat macOS/CI lint as the source of truth.
+- The repo currently has **pre-existing** SwiftLint violations on `main`; a non-zero exit from
+  `swiftlint lint` reflects code, not a broken environment.
+
+### Project generation
+
+The `.xcodeproj` is **gitignored**; `project.yml` (XcodeGen) is the source of truth. On macOS run
+`xcodegen generate` before any `xcodebuild`. XcodeGen is macOS-oriented and is not installed on
+the Linux VM.
+
+### CI note
+
+`.github/workflows/ci.yml` runs on `macos-14` and currently fails at the `xcode-select -s
+/Applications/Xcode_16.0.app` step because that Xcode version is absent from GitHub's current
+`macos-14` image — this is a CI runner-image issue, unrelated to the code or this Linux setup.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cursor Cloud development environment for **OSGKeyboard**.

OSGKeyboard is a native **iOS 18+** app (main app + custom keyboard extension + shared Swift 6/SwiftUI framework). The Cloud VM is **Linux x86_64**, so build / run / test (which require macOS + Xcode + the iOS Simulator) are **not possible here** — nearly every source file imports iOS-only frameworks (`SwiftUI`, `UIKit`, `AVFoundation`, `Speech`, `Combine`).

The one check that *does* work on Linux is **SwiftLint** (its rules are SwiftSyntax/source-based). This PR:

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section documenting the macOS-only constraint and the working SwiftLint flow.
- Configures an idempotent update script that installs the `swiftlint-static` Linux binary (v0.63.3) to `/usr/local/bin`.

No application code was modified.

## Verification

SwiftLint runs against all 30 Swift files on the Linux VM:

```
$ swiftlint lint --quiet
180 violations reported (46 errors, 134 warnings) — all pre-existing in main
```

[swiftlint_run.log](https://cursor.com/agents/bc-a77977f8-e51a-482a-b59f-e6a34027bcd2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fswiftlint_run.log)

## Notes / limitations

- **Build / Run / Test**: macOS + Xcode 16+ only (see `README.md` / `CONTRIBUTING.md` → `xcodegen generate` + `xcodebuild`). Cannot be demonstrated on this Linux VM.
- On Linux, SourceKit-only SwiftLint rules are skipped (e.g. `statement_position`); treat macOS/CI lint as authoritative.
- The repo's GitHub Actions CI currently fails at `xcode-select -s /Applications/Xcode_16.0.app` (that Xcode version is missing from the current `macos-14` runner image) — a CI runner-image issue unrelated to this change.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a77977f8-e51a-482a-b59f-e6a34027bcd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a77977f8-e51a-482a-b59f-e6a34027bcd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

