### PR TITLE
fix: auto-create Signing.local.xcconfig for xcodegen

### DIFF
--- a/Scripts/generate-xcodeproj.sh
+++ b/Scripts/generate-xcodeproj.sh
@@ -6,5 +6,19 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
+# XcodeGen requires configFiles listed in project.yml to exist on disk.
+# Signing.local.xcconfig is gitignored so each machine keeps its own team ID.
+SIGNING_LOCAL="$ROOT/Signing.local.xcconfig"
+SIGNING_EXAMPLE="$ROOT/Signing.local.xcconfig.example"
+if [[ ! -f "$SIGNING_LOCAL" ]]; then
+  if [[ ! -f "$SIGNING_EXAMPLE" ]]; then
+    echo "error: missing $SIGNING_EXAMPLE" >&2
+    exit 1
+  fi
+  cp "$SIGNING_EXAMPLE" "$SIGNING_LOCAL"
+  echo "Created $SIGNING_LOCAL from Signing.local.xcconfig.example"
+  echo "Edit DEVELOPMENT_TEAM there if you use a personal Apple Developer account."
+fi
+
 xcodegen generate
 "$ROOT/Scripts/patch-icon-composer.sh"

--- a/Signing.local.xcconfig.example
+++ b/Signing.local.xcconfig.example
@@ -1,0 +1,10 @@
+// Signing.local.xcconfig.example
+// Copy to Signing.local.xcconfig (gitignored) for local signing overrides.
+// `./Scripts/generate-xcodeproj.sh` creates Signing.local.xcconfig from this
+// file automatically when it is missing.
+//
+// Replace DEVELOPMENT_TEAM with your Apple Developer Team ID if you are not
+// building with the project's default team.
+
+DEVELOPMENT_TEAM = X329MZU23S
+CODE_SIGN_STYLE = Automatic


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`xcodegen generate` fails on fresh clones with:

```
Invalid config file "Signing.local.xcconfig" for config "Debug"
Invalid config file "Signing.local.xcconfig" for config "Release"
```

`Signing.local.xcconfig` is gitignored (intentionally, for per-developer signing overrides) but was never bootstrapped.

## Solution

- Add `Signing.local.xcconfig.example` with default team/signing settings
- Update `Scripts/generate-xcodeproj.sh` to copy the example file when `Signing.local.xcconfig` is missing
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb750644-9a62-4c6b-8a51-6ce3c9916baf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb750644-9a62-4c6b-8a51-6ce3c9916baf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

