### PR TITLE
fix: PersonalDictionary init parameter syntax

### DIFF
--- a/OSGKeyboardShared/Models/PersonalDictionary.swift
+++ b/OSGKeyboardShared/Models/PersonalDictionary.swift
@@ -23,7 +23,7 @@ public struct PersonalDictionary: Codable, Sendable, Equatable {
     public var entries: [Entry]
     public var version: Int
 
-    public init(entries: [Entry] = [], version: 1) {
+    public init(entries: [Entry] = [], version: Int = 1) {
         self.entries = entries
         self.version = version
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`PersonalDictionary.swift` fails to compile:

```
Line 26: Expected parameter type following ':'
Line 108: Missing argument for parameter 'from' in call
```

## Cause

Invalid initializer syntax `version: 1` — Swift expects `version: Int = 1`. The broken init prevents synthesis of the zero-argument initializer, so `PersonalDictionary()` on line 108 is resolved to Codable's `init(from:)` instead.

## Fix

Change to `version: Int = 1`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb750644-9a62-4c6b-8a51-6ce3c9916baf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb750644-9a62-4c6b-8a51-6ce3c9916baf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

