### PR TITLE
fix: AppContextDetector indentation check type error

### DIFF
--- a/OSGKeyboardShared/Services/AppContextDetector.swift
+++ b/OSGKeyboardShared/Services/AppContextDetector.swift
@@ -95,7 +95,7 @@ public struct AppContextDetector: Sendable {
             "if (", "if (", "} else", "} catch",
             "=> {", "-> {",
         ]
-        let hasIndentation = tail.contains(where: { $0 == "\n    " || $0 == "\t" })
+        let hasIndentation = tail.contains("\n    ") || tail.contains("\t")
         let hasCodeKeyword = codeKeywords.contains(where: { tail.contains($0) })
         if hasIndentation, hasCodeKeyword {
             return .code


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

```
AppContextDetector.swift:98:56 Binary operator '==' cannot be applied to operands of type 'Substring.Element' (aka 'Character') and 'String'
```

## Cause

`tail.contains(where: { $0 == "\n    " || $0 == "\t" })` iterates **characters**, but compares each `Character` to `String` literals — invalid in Swift 6.

## Fix

Check for indentation patterns on the substring directly:

```swift
tail.contains("\n    ") || tail.contains("\t")
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb750644-9a62-4c6b-8a51-6ce3c9916baf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb750644-9a62-4c6b-8a51-6ce3c9916baf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

