### PR TITLE
fix: ExtL10n Text/String misuse and caption1 typography

### DIFF
--- a/OSGKeyboard/Views/PersonalDictionaryView.swift
+++ b/OSGKeyboard/Views/PersonalDictionaryView.swift
@@ -85,7 +85,7 @@ struct PersonalDictionaryView: View {
                 .foregroundStyle(palette.accent)
             VStack(alignment: .leading, spacing: 4) {
                 Text("settings.personalDictionary.intro.title")
-                    .font(TypeStyle.caption1)
+                    .font(TypeStyle.caption)
                     .foregroundStyle(palette.textPrimary)
                 Text("settings.personalDictionary.intro.body")
                     .font(TypeStyle.caption2)
@@ -176,7 +176,7 @@ struct PersonalDictionaryView: View {
                 .font(TypeStyle.body)
                 .foregroundStyle(palette.textSecondary)
             Text("settings.personalDictionary.empty.body")
-                .font(TypeStyle.caption1)
+                .font(TypeStyle.caption)
                 .foregroundStyle(palette.textTertiary)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, Spacing.xl)

--- a/OSGKeyboardExt/Views/AppContextChip.swift
+++ b/OSGKeyboardExt/Views/AppContextChip.swift
@@ -57,11 +57,11 @@ struct AppContextChip: View {
     }
 
     private var chipText: String {
-        ExtL10n.text("keyboard.appContext.chip.\(state.appContext.rawValue)")
+        ExtL10n.string("keyboard.appContext.chip.\(state.appContext.rawValue)")
     }
 
     private func menuLabel(for context: AppContext) -> String {
-        ExtL10n.text("keyboard.appContext.menu.\(context.rawValue)")
+        ExtL10n.string("keyboard.appContext.menu.\(context.rawValue)")
     }
 
     private func iconName(for context: AppContext) -> String {

--- a/OSGKeyboardExt/Views/KeyboardOnboardingOverlay.swift
+++ b/OSGKeyboardExt/Views/KeyboardOnboardingOverlay.swift
@@ -132,12 +132,12 @@ struct KeyboardOnboardingOverlay: View {
             Image(systemName: "keyboard")
                 .font(.system(size: 36, weight: .light))
                 .foregroundStyle(palette.accent)
-            Text(ExtL10n.text("keyboard.onboarding.keyboard.title"))
+            Text(ExtL10n.string("keyboard.onboarding.keyboard.title"))
                 .font(TypeStyle.headline)
                 .foregroundStyle(palette.textPrimary)
                 .multilineTextAlignment(.center)
-            Text(ExtL10n.text("keyboard.onboarding.keyboard.body"))
-                .font(TypeStyle.caption1)
+            Text(ExtL10n.string("keyboard.onboarding.keyboard.body"))
+                .font(TypeStyle.caption)
                 .foregroundStyle(palette.textSecondary)
                 .multilineTextAlignment(.center)
                 .fixedSize(horizontal: false, vertical: true)
@@ -146,9 +146,9 @@ struct KeyboardOnboardingOverlay: View {
             } label: {
                 HStack(spacing: 6) {
                     Image(systemName: "arrow.up.right.square")
-                    Text(ExtL10n.text("keyboard.onboarding.keyboard.openSettings"))
+                    Text(ExtL10n.string("keyboard.onboarding.keyboard.openSettings"))
                 }
-                .font(TypeStyle.caption1.weight(.semibold))
+                .font(TypeStyle.caption.weight(.semibold))
                 .foregroundStyle(.white)
                 .padding(.horizontal, Spacing.md)
                 .padding(.vertical, Spacing.xs + 2)
@@ -164,16 +164,16 @@ struct KeyboardOnboardingOverlay: View {
             Image(systemName: "key.fill")
                 .font(.system(size: 32, weight: .light))
                 .foregroundStyle(palette.accent)
-            Text(ExtL10n.text("keyboard.onboarding.api.title"))
+            Text(ExtL10n.string("keyboard.onboarding.api.title"))
                 .font(TypeStyle.headline)
                 .foregroundStyle(palette.textPrimary)
                 .multilineTextAlignment(.center)
-            Text(ExtL10n.text("keyboard.onboarding.api.body"))
-                .font(TypeStyle.caption1)
+            Text(ExtL10n.string("keyboard.onboarding.api.body"))
+                .font(TypeStyle.caption)
                 .foregroundStyle(palette.textSecondary)
                 .multilineTextAlignment(.center)
                 .fixedSize(horizontal: false, vertical: true)
-            Text(ExtL10n.text("keyboard.onboarding.api.skipHint"))
+            Text(ExtL10n.string("keyboard.onboarding.api.skipHint"))
                 .font(TypeStyle.caption2)
                 .foregroundStyle(palette.textSecondary)
                 .multilineTextAlignment(.center)
@@ -190,12 +190,12 @@ struct KeyboardOnboardingOverlay: View {
             Image(systemName: iconSystemName)
                 .font(.system(size: 36, weight: .light))
                 .foregroundStyle(palette.accent)
-            Text(ExtL10n.text(title))
+            Text(ExtL10n.string(title))
                 .font(TypeStyle.headline)
                 .foregroundStyle(palette.textPrimary)
                 .multilineTextAlignment(.center)
-            Text(ExtL10n.text(body))
-                .font(TypeStyle.caption1)
+            Text(ExtL10n.string(body))
+                .font(TypeStyle.caption)
                 .foregroundStyle(palette.textSecondary)
                 .multilineTextAlignment(.center)
                 .fixedSize(horizontal: false, vertical: true)
@@ -208,10 +208,10 @@ struct KeyboardOnboardingOverlay: View {
     private var footer: some View {
         HStack(spacing: Spacing.xs) {
             if currentStep != .welcome {
-                Button(ExtL10n.text("keyboard.onboarding.back")) {
+                Button(ExtL10n.string("keyboard.onboarding.back")) {
                     state.onboardingPage = max(0, currentStep.rawValue - 1)
                 }
-                .font(TypeStyle.caption1)
+                .font(TypeStyle.caption)
                 .foregroundStyle(palette.textSecondary)
                 .frame(minHeight: 36)
             }
@@ -226,13 +226,13 @@ struct KeyboardOnboardingOverlay: View {
     private var primaryButton: some View {
         switch currentStep {
         case .welcome:
-            Button(ExtL10n.text("keyboard.onboarding.getStarted")) {
+            Button(ExtL10n.string("keyboard.onboarding.getStarted")) {
                 state.onboardingPage = 1
             }
             .buttonStyle(OverlayPrimaryButtonStyle(palette: palette))
 
         case .microphone:
-            Button(ExtL10n.text("keyboard.onboarding.mic.grant")) {
+            Button(ExtL10n.string("keyboard.onboarding.mic.grant")) {
                 state.requestMicPermission()
                 // Optimistically advance — if permission is denied the
                 // status text on the next viewWillAppear will reflect it.
@@ -241,7 +241,7 @@ struct KeyboardOnboardingOverlay: View {
             .buttonStyle(OverlayPrimaryButtonStyle(palette: palette))
 
         case .speech:
-            Button(ExtL10n.text("keyboard.onboarding.speech.grant")) {
+            Button(ExtL10n.string("keyboard.onboarding.speech.grant")) {
                 state.requestSpeechPermission()
                 state.onboardingPage = 3
             }
@@ -252,22 +252,22 @@ struct KeyboardOnboardingOverlay: View {
             // has enabled the keyboard in Settings.app. We don't show
             // a "Continue" button here — that would re-trigger the
             // confusion we're solving.
-            Button(ExtL10n.text("keyboard.onboarding.keyboard.openSettings")) {
+            Button(ExtL10n.string("keyboard.onboarding.keyboard.openSettings")) {
                 state.openSystemSettings()
             }
             .buttonStyle(OverlayPrimaryButtonStyle(palette: palette))
 
         case .api:
             HStack(spacing: Spacing.xs) {
-                Button(ExtL10n.text("keyboard.onboarding.api.skip")) {
+                Button(ExtL10n.string("keyboard.onboarding.api.skip")) {
                     state.completeOnboarding()
                 }
-                .font(TypeStyle.caption1)
+                .font(TypeStyle.caption)
                 .foregroundStyle(palette.textSecondary)
                 .padding(.horizontal, Spacing.sm)
                 .frame(minHeight: 36)
 
-                Button(ExtL10n.text("keyboard.onboarding.api.openHostApp")) {
+                Button(ExtL10n.string("keyboard.onboarding.api.openHostApp")) {
                     state.openSettings()
                 }
                 .buttonStyle(OverlayPrimaryButtonStyle(palette: palette))
@@ -281,7 +281,7 @@ private struct OverlayPrimaryButtonStyle: ButtonStyle {
 
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .font(TypeStyle.caption1.weight(.semibold))
+            .font(TypeStyle.caption.weight(.semibold))
             .foregroundStyle(.white)
             .padding(.horizontal, Spacing.md)
             .padding(.vertical, Spacing.xs + 2)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Swift 6 build failures in keyboard extension views:

- `AppContextChip`: `ExtL10n.text()` returns `Text`, used where `String` is expected
- `KeyboardOnboardingOverlay`: `Text(ExtL10n.text(...))` and `Button(ExtL10n.text(...))` double-wrap / wrong types
- `TypeStyle.caption1` does not exist (design system defines `caption` and `caption2`)

## Fix

- Use `ExtL10n.string()` for `String` contexts; keep `ExtL10n.text()` only where a `Text` view is the direct label
- Replace `TypeStyle.caption1` with `TypeStyle.caption` in onboarding + personal dictionary views
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb750644-9a62-4c6b-8a51-6ce3c9916baf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb750644-9a62-4c6b-8a51-6ce3c9916baf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

