### PR TITLE
fix: AppGroupStore onboarding writes from let binding

### DIFF
--- a/OSGKeyboardExt/KeyboardViewController.swift
+++ b/OSGKeyboardExt/KeyboardViewController.swift
@@ -208,14 +208,14 @@ public final class KeyboardViewController: UIInputViewController {
     private func advanceOnboarding() {
         let store = AppGroupStore()
         let nextPage = min(4, store.onboardingPage + 1)
-        store.onboardingPage = nextPage
+        store.setOnboardingPage(nextPage)
         state.onboardingPage = nextPage
     }
 
     private func completeOnboarding() {
         let store = AppGroupStore()
-        store.hasCompletedOnboarding = true
-        store.onboardingPage = 4
+        store.setHasCompletedOnboarding(true)
+        store.setOnboardingPage(4)
         state.hasCompletedOnboarding = true
         state.onboardingPage = 4
     }
@@ -351,7 +351,7 @@ public final class KeyboardViewController: UIInputViewController {
         guard state.onboardingPage == 3 else { return }
         guard KeyboardSetupBridge.isReadyForOnboardingSkip else { return }
         let store = AppGroupStore()
-        store.onboardingPage = 4
+        store.setOnboardingPage(4)
         state.onboardingPage = 4
     }
 

--- a/OSGKeyboardShared/Services/AppGroupStore.swift
+++ b/OSGKeyboardShared/Services/AppGroupStore.swift
@@ -293,6 +293,14 @@ public struct AppGroupStore: @unchecked Sendable {
         set { defaults.set(newValue, forKey: "config.onboardingPage") }
     }
 
+    public func setHasCompletedOnboarding(_ completed: Bool) {
+        defaults.set(completed, forKey: "config.hasCompletedOnboarding")
+    }
+
+    public func setOnboardingPage(_ page: Int) {
+        defaults.set(page, forKey: "config.onboardingPage")
+    }
+
     // MARK: - Detected app context (v0.3.0+)
 
     /// Last app context the keyboard extension detected for this


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

```
Cannot assign to property: 'store' is a 'let' constant
```

in `KeyboardViewController` when writing onboarding flags via `AppGroupStore`.

## Cause

`AppGroupStore` is a **struct**. Property setters are `mutating`, so they cannot be invoked on `let store = AppGroupStore()`.

## Fix

Add non-mutating helpers `setOnboardingPage(_:)` and `setHasCompletedOnboarding(_:)`, matching the existing `setDetectedAppContext` pattern.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb750644-9a62-4c6b-8a51-6ce3c9916baf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb750644-9a62-4c6b-8a51-6ce3c9916baf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

