### PR TITLE
fix: PersonalDictionaryView preview and dictionary persistence

### DIFF
--- a/OSGKeyboard/Services/DictionaryLearner.swift
+++ b/OSGKeyboard/Services/DictionaryLearner.swift
@@ -144,7 +144,7 @@ final class DictionaryLearner {
 
         if didChange {
             dictionary.version += 1
-            store.personalDictionary = dictionary
+            store.setPersonalDictionary(dictionary)
         }
         // Suppress the "did not change" path; we still return the
         // bumped-counts view so the caller can refresh a UI label.

--- a/OSGKeyboard/Views/PersonalDictionaryView.swift
+++ b/OSGKeyboard/Views/PersonalDictionaryView.swift
@@ -224,11 +224,14 @@ struct PersonalDictionaryView: View {
 
     private func persist() {
         dictionary.version += 1
-        store.personalDictionary = dictionary
+        store.setPersonalDictionary(dictionary)
     }
 }
 
+#if DEBUG
 #Preview {
-    PersonalDictionaryView()
-        .environment(\.themePalette, ThemePalette())
+    ThemedRoot {
+        PersonalDictionaryView()
+    }
 }
+#endif

--- a/OSGKeyboardShared/Services/AppGroupStore.swift
+++ b/OSGKeyboardShared/Services/AppGroupStore.swift
@@ -341,14 +341,18 @@ public struct AppGroupStore: @unchecked Sendable {
             }
         }
         set {
-            do {
-                let data = try JSONEncoder().encode(newValue)
-                defaults.set(data, forKey: Key.personalDictionary)
-            } catch {
-                #if DEBUG
-                print("⚠️ [AppGroupStore] personalDictionary encode failed: \(error)")
-                #endif
-            }
+            setPersonalDictionary(newValue)
+        }
+    }
+
+    public func setPersonalDictionary(_ dictionary: PersonalDictionary) {
+        do {
+            let data = try JSONEncoder().encode(dictionary)
+            defaults.set(data, forKey: Key.personalDictionary)
+        } catch {
+            #if DEBUG
+            print("⚠️ [AppGroupStore] personalDictionary encode failed: \(error)")
+            #endif
         }
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Fixes

1. **Preview** — `ThemePalette()` initializer is internal; wrap preview in `ThemedRoot` like other app views.
2. **Personal dictionary persistence** — `AppGroupStore` is a struct; add `setPersonalDictionary(_:)` and use it from `PersonalDictionaryView` and `DictionaryLearner` instead of property assignment on `let store`.

## Note on caption1

`TypeStyle.caption1` was already replaced with `caption` in PR #12. Pull latest `main` if those errors persist locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb750644-9a62-4c6b-8a51-6ce3c9916baf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb750644-9a62-4c6b-8a51-6ce3c9916baf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

