### PR TITLE
fix: remove stale SettingsView section references

### DIFF
--- a/OSGKeyboard/Views/SettingsView.swift
+++ b/OSGKeyboard/Views/SettingsView.swift
@@ -74,11 +74,7 @@ struct SettingsView: View {
                                 providerSection
                                 apiSection
                             }
-                            languageAndModelsSection
                             polishIntensitySection
-                            if config.engineMode == "cloud" {
-                                systemPromptLinkSection
-                            }
                             if config.engineMode == "local" {
                                 localEngineSettingsSection
                             }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

SettingsView fails to compile:

```
Cannot find 'languageAndModelsSection' in scope
Cannot find 'systemPromptLinkSection' in scope
```

OSGKeyboardExt `Ld` failure is a cascade from the main app not building.

## Cause

v0.3 polish-scenario refactor renamed `languageAndModelsSection` → `languageAndPolishSection` and folded the system-prompt link into that section (custom scenario only). The intelligent-polish merge re-added stale references in `body` without restoring the removed computed properties.

## Fix

Remove the two obsolete `body` references. Functionality is already covered by `languageAndPolishSection`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb750644-9a62-4c6b-8a51-6ce3c9916baf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb750644-9a62-4c6b-8a51-6ce3c9916baf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

