### PR TITLE
fix: XcodeGen 2.45 wrapper.icon AppIcon patch

### DIFF
--- a/Scripts/patch-icon-composer.sh
+++ b/Scripts/patch-icon-composer.sh
@@ -23,7 +23,7 @@ import sys
 import uuid
 from pathlib import Path
 
-PATCH_VERSION = 3
+PATCH_VERSION = 4
 
 def extract_block(text: str, brace_open: int) -> tuple[str, int] | None:
     depth = 0
@@ -53,6 +53,28 @@ text = pbxproj.read_text()
 if is_valid_icon_setup(text):
     print(f"AppIcon.icon already configured (patch v{PATCH_VERSION})")
     sys.exit(0)
+
+# XcodeGen 2.45 emits a single-line PBXFileReference with
+# lastKnownFileType = wrapper.icon. Upgrade that in place first.
+wrapper_icon_pattern = re.compile(
+    r"(?P<prefix>[A-F0-9]{24} /\* AppIcon\.icon \*/ = \{[^}]*lastKnownFileType = )wrapper\.icon(?P<suffix>; path = AppIcon\.icon;[^}]*\};)"
+)
+wrapper_match = wrapper_icon_pattern.search(text)
+if wrapper_match:
+    text = (
+        text[: wrapper_match.start()]
+        + wrapper_match.group("prefix")
+        + "folder.iconcomposer.icon"
+        + wrapper_match.group("suffix")
+        + text[wrapper_match.end() :]
+    )
+    if is_valid_icon_setup(text):
+        pbxproj.write_text(text)
+        print(
+            f"Patched AppIcon.icon wrapper.icon -> folder.iconcomposer.icon "
+            f"(patch v{PATCH_VERSION})"
+        )
+        sys.exit(0)
 
 icon_ref_match = None
 for pattern in (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

XcodeGen 2.45.4 emits AppIcon.icon as a **single-line** PBX entry:

```
lastKnownFileType = wrapper.icon; path = AppIcon.icon;
```

The compatibility patch failed on older script versions with `unexpected shape`. Users also could not `git pull` due to local edits overlapping remote fixes.

## Fix

Add a fast path in `patch-icon-composer.sh` v4: replace `wrapper.icon` → `folder.iconcomposer.icon` in place when AppIcon is already in Resources.

## User sync steps

```bash
git reset --hard origin/main   # discard overlapping local edits
git pull origin main
rm -rf OSGKeyboard.xcodeproj
./Scripts/generate-xcodeproj.sh
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb750644-9a62-4c6b-8a51-6ce3c9916baf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb750644-9a62-4c6b-8a51-6ce3c9916baf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

