### PR TITLE
设置页与引导页 UI 简化

### DIFF
--- a/OSGKeyboard/Views/OnboardingView.swift
+++ b/OSGKeyboard/Views/OnboardingView.swift
@@ -757,35 +757,8 @@ private struct APISetupPage: View {
                     .padding(.horizontal, Spacing.lg)
                 }
 
-                if config.isPolishScenarioRowVisible {
-                    postProcessingSection
-                        .padding(.horizontal, Spacing.lg)
-                }
             }
             .padding(.bottom, Spacing.xxxl)
-        }
-    }
-
-    /// Polish scenario + optional translation target for cloud onboarding.
-    private var postProcessingSection: some View {
-        VStack(alignment: .leading, spacing: SettingsListMetrics.sectionLabelSpacing) {
-            Text("settings.polishScenario.section")
-                .font(TypeStyle.caption2)
-                .foregroundStyle(palette.textSecondary)
-                .textCase(.uppercase)
-                .frame(maxWidth: .infinity, alignment: .leading)
-            VStack(spacing: 0) {
-                ScenarioPickerRow(config: config, isVisible: true)
-                if config.isTranslationRowVisible {
-                    Divider().background(palette.divider)
-                    TranslationPickerRow(config: config, isVisible: true)
-                }
-            }
-            .background(palette.surface, in: RoundedRectangle(cornerRadius: Radius.large, style: .continuous))
-            .overlay(
-                RoundedRectangle(cornerRadius: Radius.large, style: .continuous)
-                    .stroke(palette.divider, lineWidth: 0.5)
-            )
         }
     }
 }

--- a/OSGKeyboard/Views/PersonalDictionaryView.swift
+++ b/OSGKeyboard/Views/PersonalDictionaryView.swift
@@ -40,7 +40,8 @@ struct PersonalDictionaryView: View {
                 list
             }
         }
-        .background(palette.background.ignoresSafeArea())
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(palette.surface.ignoresSafeArea())
         .navigationTitle("settings.personalDictionary.title")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar(.visible, for: .navigationBar)
@@ -56,7 +57,7 @@ struct PersonalDictionaryView: View {
                 }
             }
         }
-        .toolbarBackground(palette.background, for: .navigationBar)
+        .toolbarBackground(palette.surface, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
         .confirmationDialog(
             AppL10n.string("settings.personalDictionary.clearAll.confirmTitle"),
@@ -180,7 +181,7 @@ struct PersonalDictionaryView: View {
     private var emptyState: some View {
         VStack(spacing: Spacing.sm) {
             Spacer()
-            MaterialIcon(name: .bookmark, size: 36)
+            MaterialIcon(name: .menuBook, size: 36)
                 .foregroundStyle(palette.textTertiary.opacity(0.5))
             Text("settings.personalDictionary.empty.title")
                 .font(TypeStyle.body)

--- a/OSGKeyboard/Views/SettingsView.swift
+++ b/OSGKeyboard/Views/SettingsView.swift
@@ -304,34 +304,12 @@ struct SettingsView: View {
             }
             .pickerStyle(.segmented)
             .padding(.horizontal, Spacing.md)
-
-            Text(SharedL10n.string(config.polishIntensity.descriptionKey, language: config.uiLanguage))
-                .font(TypeStyle.caption2)
-                .foregroundStyle(palette.textSecondary)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, Spacing.md)
-                .padding(.bottom, Spacing.sm)
+            .padding(.bottom, Spacing.sm)
         }
     }
 
     private var personalDictionaryPreferenceRow: some View {
-        HStack(spacing: Spacing.sm) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text("settings.personalDictionary.title")
-                    .font(TypeStyle.body)
-                    .foregroundStyle(palette.textPrimary)
-                Text("settings.personalDictionary.summary")
-                    .font(TypeStyle.caption2)
-                    .foregroundStyle(palette.textSecondary)
-            }
-            Spacer()
-            Image(systemName: "chevron.right")
-                .font(.system(size: 14, weight: .semibold))
-                .foregroundStyle(palette.textTertiary)
-        }
-        .padding(.horizontal, Spacing.md)
-        .frame(minHeight: SettingsListMetrics.doubleLineMinHeight)
-        .contentShape(Rectangle())
+        footerNavigationRow(title: "settings.personalDictionary.title")
     }
 
     // MARK: - Footer links (tab settings only)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

四项 UI 调整，让设置与引导流程更简洁一致。

## Changes

1. **设置 → 偏好**：去掉润色档位说明小字、个性化词库副标题，词库入口改为单行导航样式
2. **个性化词库页**：背景统一为 `palette.surface`（浅色下近白），修复中间灰、两侧白的色差
3. **词库空白态**：图标由书签改为图书馆样式（`menuBook`，与历史页一致）
4. **首次引导**：移除页面底部的润色场景与润色后翻译区块

## Files

- `OSGKeyboard/Views/SettingsView.swift`
- `OSGKeyboard/Views/PersonalDictionaryView.swift`
- `OSGKeyboard/Views/OnboardingView.swift`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb750644-9a62-4c6b-8a51-6ce3c9916baf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb750644-9a62-4c6b-8a51-6ce3c9916baf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

