### PR TITLE
fix: import OSGKeyboardShared in UsageStatisticsStore

### DIFF
--- a/OSGKeyboard/Services/UsageStatisticsStore.swift
+++ b/OSGKeyboard/Services/UsageStatisticsStore.swift
@@ -6,6 +6,7 @@
 
 import Foundation
 import Combine
+import OSGKeyboardShared
 
 struct UsageStatistics: Codable, Equatable {
     var dictationDurationSeconds: TimeInterval


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds missing `import OSGKeyboardShared` so `AppUILanguage` resolves in `UsageStatisticsStore`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb750644-9a62-4c6b-8a51-6ce3c9916baf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb750644-9a62-4c6b-8a51-6ce3c9916baf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

