### PR TITLE
fix: HomeStatsCard background ShapeStyle compile error

### DIFF
--- a/OSGKeyboard/Views/Components/HomeStatsCard.swift
+++ b/OSGKeyboard/Views/Components/HomeStatsCard.swift
@@ -57,7 +57,21 @@ struct HomeStatsCard: View {
                 )
             }
         }
-        .background(cardBackground, in: RoundedRectangle(cornerRadius: Radius.xl, style: .continuous))
+        .background {
+            ZStack(alignment: .top) {
+                palette.surface
+                LinearGradient(
+                    colors: [
+                        palette.accent.opacity(0.10),
+                        palette.accent.opacity(0.02),
+                        palette.surface.opacity(0)
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            }
+        }
+        .clipShape(RoundedRectangle(cornerRadius: Radius.xl, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: Radius.xl, style: .continuous)
                 .stroke(palette.divider, lineWidth: 0.5)
@@ -65,21 +79,6 @@ struct HomeStatsCard: View {
         .onAppear(perform: refreshDictionaryCount)
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
             refreshDictionaryCount()
-        }
-    }
-
-    private var cardBackground: some View {
-        ZStack(alignment: .top) {
-            palette.surface
-            LinearGradient(
-                colors: [
-                    palette.accent.opacity(0.10),
-                    palette.accent.opacity(0.02),
-                    palette.surface.opacity(0)
-                ],
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing
-            )
         }
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes SwiftUI compile error: `.background(_:in:)` requires `ShapeStyle`, not a `View`. Uses `background { }` + `clipShape` for the gradient card fill.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb750644-9a62-4c6b-8a51-6ce3c9916baf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb750644-9a62-4c6b-8a51-6ce3c9916baf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

