### PR TITLE
fix(flow): improve tail capture and final chunk ASR recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Flow tail ASR drop**: after mic stop, iOS Flow now uses a longer silence drain (350 ms), a fixed 150 ms post-roll, expanded final-chunk ASR recovery, and a partial transcript guard so weak trailing syllables are less likely to disappear from the result. / **Flow 尾音识别丢失**：松手后 iOS Flow 采用更长的静音排空（350 ms）、固定 150 ms 尾音保留、增强末块 ASR 恢复与 partial 兜底，降低弱尾音从结果中消失的概率。
+- **Flow batch ASR fallback**: when pipelined chunk output is clearly shorter than the live partial, the host re-transcribes the full utterance PCM captured during recording (Mac-style safety net). / **Flow 整句 ASR 兜底**：流水线拼接结果明显短于实时 partial 时，主 App 对录音期间累积的整段 PCM 重新识别（对齐 Mac 双保险）。
+
+### Changed
+- **Mac MLX tail drain**: streaming capture now uses the shared `FlowUtteranceEndCoordinator` (silence drain + post-roll) instead of an inline poll loop. / **Mac MLX 尾音排空**：流式采集改用 Shared 层 `FlowUtteranceEndCoordinator`（静音排空 + post-roll），替代内联轮询循环。
 
 ### Added
 - **Mac MLX streaming ASR**: local dictation uses Qwen3-ASR via mlx-audio-swift with overlay partial preview, tail drain, vocabulary prompt, and polish-before-insert. / **Mac MLX 流式 ASR**：本地听写改用 mlx-audio-swift 的 Qwen3-ASR，支持浮层 partial 预览、尾部截断、词库 prompt 与润色后再插入。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Flow tail ASR drop**: after mic stop, iOS Flow now uses a longer silence drain (350 ms), a fixed 150 ms post-roll, expanded final-chunk ASR recovery, and a partial transcript guard so weak trailing syllables are less likely to disappear from the result. / **Flow 尾音识别丢失**：松手后 iOS Flow 采用更长的静音排空（350 ms）、固定 150 ms 尾音保留、增强末块 ASR 恢复与 partial 兜底，降低弱尾音从结果中消失的概率。
+
 ### Added
 - **Mac MLX streaming ASR**: local dictation uses Qwen3-ASR via mlx-audio-swift with overlay partial preview, tail drain, vocabulary prompt, and polish-before-insert. / **Mac MLX 流式 ASR**：本地听写改用 mlx-audio-swift 的 Qwen3-ASR，支持浮层 partial 预览、尾部截断、词库 prompt 与润色后再插入。
 

--- a/OSGKeyboard/Services/FlowSessionManager.swift
+++ b/OSGKeyboard/Services/FlowSessionManager.swift
@@ -64,6 +64,8 @@ final class FlowSessionManager: ObservableObject {
     private var chunkedPipeline: ChunkedUtterancePipeline?
     private var currentPartial = ""
     private var lastFinal = ""
+    /// Partial stitched text captured when the user stops recording.
+    private var bestPartialSnapshot = ""
     private var chunkWarnings: [String] = []
     private var lastReadyTraceSignature = ""
     private var lastCommandFingerprint = ""
@@ -356,6 +358,7 @@ final class FlowSessionManager: ObservableObject {
         sessionWarning = nil
         currentPartial = ""
         lastFinal = ""
+        bestPartialSnapshot = ""
         chunkWarnings = []
         FlowSessionBridge.setHostReady(false)
     }
@@ -1101,6 +1104,7 @@ final class FlowSessionManager: ObservableObject {
         currentCommandSeq = commandSeq
         currentPartial = ""
         lastFinal = ""
+        bestPartialSnapshot = ""
         chunkWarnings = []
 
         let localeId = store.localeId
@@ -1194,6 +1198,9 @@ final class FlowSessionManager: ObservableObject {
         refreshHostReady()
         FlowLiveActivityController.update(phase: .processing)
 
+        // Snapshot pipelined partial before drain — fallback if the final chunk ASR drops tail text.
+        bestPartialSnapshot = currentPartial.trimmingCharacters(in: .whitespacesAndNewlines)
+
         // Do NOT cancel `asrTask` or `asr` — drain trailing PCM, then finalize.
 
         // Capture ids now: a cancelled finalize must still clear *this*
@@ -1231,6 +1238,7 @@ final class FlowSessionManager: ObservableObject {
         capture.cancelUtterance()
         currentPartial = ""
         lastFinal = ""
+        bestPartialSnapshot = ""
         chunkWarnings = []
         currentUtteranceId = nil
         currentCommandSeq = 0
@@ -1257,6 +1265,7 @@ final class FlowSessionManager: ObservableObject {
         capture.cancelUtterance()
         currentPartial = ""
         lastFinal = ""
+        bestPartialSnapshot = ""
         chunkWarnings = []
         storeCurrentError(message, kind: kind)
         currentUtteranceId = nil
@@ -1279,6 +1288,7 @@ final class FlowSessionManager: ObservableObject {
         chunkedPipeline = nil
         currentPartial = ""
         lastFinal = ""
+        bestPartialSnapshot = ""
         chunkWarnings = []
         storeCurrentError(message, kind: kind)
         currentUtteranceId = nil
@@ -1331,7 +1341,10 @@ final class FlowSessionManager: ObservableObject {
         let asrElapsed = Date().timeIntervalSince(pipelineStarted)
         FlowDiagnostics.log("ASR phase done in \(String(format: "%.1f", asrElapsed))s finalLen=\(lastFinal.count)")
 
-        var text = lastFinal.trimmingCharacters(in: .whitespacesAndNewlines)
+        var text = UtteranceTranscriptGuard.resolve(
+            stitchedFinal: lastFinal,
+            partialSnapshot: bestPartialSnapshot
+        )
         if text.isEmpty {
             text = currentPartial.trimmingCharacters(in: .whitespacesAndNewlines)
         }
@@ -1427,6 +1440,7 @@ final class FlowSessionManager: ObservableObject {
 
         currentPartial = ""
         lastFinal = ""
+        bestPartialSnapshot = ""
         chunkWarnings = []
         chunkedPipeline = nil
         debug("utterance finalized length=\(text.count)")

--- a/OSGKeyboard/Services/FlowSessionManager.swift
+++ b/OSGKeyboard/Services/FlowSessionManager.swift
@@ -66,6 +66,8 @@ final class FlowSessionManager: ObservableObject {
     private var lastFinal = ""
     /// Partial stitched text captured when the user stops recording.
     private var bestPartialSnapshot = ""
+    /// Full utterance PCM for batch ASR fallback after pipelined chunking.
+    private var utterancePCMSamples: [Float] = []
     private var chunkWarnings: [String] = []
     private var lastReadyTraceSignature = ""
     private var lastCommandFingerprint = ""
@@ -359,6 +361,7 @@ final class FlowSessionManager: ObservableObject {
         currentPartial = ""
         lastFinal = ""
         bestPartialSnapshot = ""
+        utterancePCMSamples = []
         chunkWarnings = []
         FlowSessionBridge.setHostReady(false)
     }
@@ -1105,6 +1108,7 @@ final class FlowSessionManager: ObservableObject {
         currentPartial = ""
         lastFinal = ""
         bestPartialSnapshot = ""
+        utterancePCMSamples = []
         chunkWarnings = []
 
         let localeId = store.localeId
@@ -1214,6 +1218,7 @@ final class FlowSessionManager: ObservableObject {
             guard let self else { return }
             let drainReport = await self.capture.endUtteranceAndDrain()
             FlowDiagnostics.logDrain(drainReport)
+            self.utterancePCMSamples = self.capture.consumeUtteranceSamples()
             await self.finalizeUtterance(
                 sessionId: drainingSessionId,
                 utteranceId: drainingUtteranceId,
@@ -1239,6 +1244,7 @@ final class FlowSessionManager: ObservableObject {
         currentPartial = ""
         lastFinal = ""
         bestPartialSnapshot = ""
+        utterancePCMSamples = []
         chunkWarnings = []
         currentUtteranceId = nil
         currentCommandSeq = 0
@@ -1266,6 +1272,7 @@ final class FlowSessionManager: ObservableObject {
         currentPartial = ""
         lastFinal = ""
         bestPartialSnapshot = ""
+        utterancePCMSamples = []
         chunkWarnings = []
         storeCurrentError(message, kind: kind)
         currentUtteranceId = nil
@@ -1289,6 +1296,7 @@ final class FlowSessionManager: ObservableObject {
         currentPartial = ""
         lastFinal = ""
         bestPartialSnapshot = ""
+        utterancePCMSamples = []
         chunkWarnings = []
         storeCurrentError(message, kind: kind)
         currentUtteranceId = nil
@@ -1348,6 +1356,14 @@ final class FlowSessionManager: ObservableObject {
         if text.isEmpty {
             text = currentPartial.trimmingCharacters(in: .whitespacesAndNewlines)
         }
+
+        if UtteranceBatchFallbackPolicy.shouldRunBatchFallback(
+            stitchedFinal: lastFinal,
+            partialSnapshot: bestPartialSnapshot
+        ), !utterancePCMSamples.isEmpty {
+            text = await runBatchASRFallback(currentText: text)
+        }
+        utterancePCMSamples = []
         guard !text.isEmpty else {
             let key = (asrTask?.isCancelled == true || Task.isCancelled)
                 ? "flow.error.recognitionInterrupted"
@@ -1441,6 +1457,7 @@ final class FlowSessionManager: ObservableObject {
         currentPartial = ""
         lastFinal = ""
         bestPartialSnapshot = ""
+        utterancePCMSamples = []
         chunkWarnings = []
         chunkedPipeline = nil
         debug("utterance finalized length=\(text.count)")
@@ -1567,6 +1584,49 @@ final class FlowSessionManager: ObservableObject {
             engineMode: engineMode,
             chunkWarning: chunkWarning
         )
+    }
+
+    /// Re-transcribe the full utterance PCM when pipelined chunking likely dropped tail text.
+    private func runBatchASRFallback(currentText: String) async -> String {
+        let samples = utterancePCMSamples
+        guard !samples.isEmpty else { return currentText }
+
+        let locale = SpeechLocaleResolver.resolve(store.localeId)
+        let stitched = lastFinal.trimmingCharacters(in: .whitespacesAndNewlines)
+        let partial = bestPartialSnapshot.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        FlowDiagnostics.log(
+            "batch fallback start samples=\(samples.count) stitchedLen=\(stitched.count) partialLen=\(partial.count)"
+        )
+
+        let asrService = asr
+        let result = await Task.detached(priority: .userInitiated) { [asrService] in
+            await asrService.transcribeChunk(samples: samples, locale: locale)
+        }.value
+
+        switch result {
+        case .success(let batchText):
+            let trimmedBatch = batchText.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedBatch.isEmpty else { return currentText }
+            let resolved = UtteranceBatchFallbackPolicy.preferredTranscript(
+                batch: trimmedBatch,
+                stitchedFinal: stitched,
+                partialSnapshot: partial,
+                current: currentText
+            )
+            FlowPipelineDiagnostics.logBatchFallback(
+                sampleCount: samples.count,
+                stitchedLength: stitched.count,
+                partialLength: partial.count,
+                batchLength: trimmedBatch.count
+            )
+            return resolved
+        case .failure(let message):
+            FlowDiagnostics.log("batch fallback failed: \(message)")
+            return currentText
+        case .cancelled:
+            return currentText
+        }
     }
 
     private func asrWaitTimeout() -> TimeInterval {

--- a/OSGKeyboardMac/MacMLXLiveCapture.swift
+++ b/OSGKeyboardMac/MacMLXLiveCapture.swift
@@ -7,11 +7,7 @@ import Foundation
 import os
 
 enum MacMLXLiveCapture {
-    private static let tailDrainPolicy = FlowCaptureTailDrainPolicy(
-        silenceRMSThreshold: 0.015,
-        silenceDurationSeconds: 0.35,
-        maxDrainSeconds: 0.75
-    )
+    private static let tailDrainPolicy = FlowCaptureTailDrainPolicy.macMLX
 
     /// Runs MLX streaming ASR until `finishSignal` fires, then tail-drains and finalizes.
     static func run(

--- a/OSGKeyboardMac/MacMLXLiveCapture.swift
+++ b/OSGKeyboardMac/MacMLXLiveCapture.swift
@@ -43,6 +43,7 @@ enum MacMLXLiveCapture {
 
             let drainTracker = FlowCaptureDrainTracker()
             let draining = OSAllocatedUnfairLock(initialState: false)
+            let drainComplete = OSAllocatedUnfairLock(initialState: false)
             let pendingFeed = OSAllocatedUnfairLock(initialState: [Float]())
             let feedIntervalSamples = 1_600 // 100 ms @ 16 kHz
 
@@ -56,6 +57,11 @@ enum MacMLXLiveCapture {
                     for await _ in finishSignal {
                         draining.withLock { $0 = true }
                         drainTracker.beginDrain()
+                        _ = await FlowUtteranceEndCoordinator.awaitTailCapture(
+                            tracker: drainTracker,
+                            policy: tailDrainPolicy
+                        )
+                        drainComplete.withLock { $0 = true }
                         break
                     }
                 }
@@ -63,10 +69,12 @@ enum MacMLXLiveCapture {
                 group.addTask {
                     for await snapshot in audioStream {
                         if Task.isCancelled { break }
+                        if drainComplete.withLock({ $0 }) { break }
                         if draining.withLock({ $0 }) {
-                            drainTracker.noteAudio(samples: snapshot.samples, policy: tailDrainPolicy)
-                            let decision = drainTracker.shouldFinish(policy: tailDrainPolicy)
-                            if decision.finished { break }
+                            drainTracker.noteAudio(
+                                samples: snapshot.samples,
+                                policy: tailDrainPolicy
+                            )
                         }
                         pendingFeed.withLock { buffer in
                             buffer.append(contentsOf: snapshot.samples)

--- a/OSGKeyboardShared/Services/ChunkedUtterancePipeline.swift
+++ b/OSGKeyboardShared/Services/ChunkedUtterancePipeline.swift
@@ -101,6 +101,7 @@ public actor ChunkedUtterancePipeline {
         var processedChunks = 0
         var previousChunkSamples: [Float] = []
         var lastChunkSamples = 0
+        var didRetryEmptyFinal = false
 
         let feeder = Task {
             for await chunk in UtteranceStreamChunker.chunks(from: stream, config: config) {
@@ -118,20 +119,28 @@ public actor ChunkedUtterancePipeline {
 
             guard let chunk = await queue.dequeue() else { break }
 
+            if chunk.isLast && chunk.samples.isEmpty {
+                continue
+            }
+
             processedChunks += 1
             lastChunkSamples = chunk.samples.count
 
-            if chunk.isLast,
-               chunk.samples.count < config.minFinalChunkSamples,
-               processedChunks > 1,
-               !previousChunkSamples.isEmpty {
-                let mergedSamples = Array(previousChunkSamples.suffix(config.overlapSamples))
-                    + chunk.samples
-                let mergedResult = await transcribeChunk(samples: mergedSamples)
+            if let preMerge = FinalChunkRecovery.preMergePlan(
+                chunk: chunk,
+                processedChunks: processedChunks,
+                previousChunkSamples: previousChunkSamples,
+                config: config
+            ) {
+                FlowPipelineDiagnostics.logFinalChunkRecovery(
+                    action: "preMerge",
+                    chunkIndex: chunk.index
+                )
+                let mergedResult = await transcribeChunk(samples: preMerge.samples)
                 switch mergedResult {
                 case .success(let text):
                     stitcher.removeLastSegment()
-                    stitcher.append(index: max(0, chunk.index - 1), text: text)
+                    stitcher.append(index: preMerge.stitchIndex, text: text)
                     publishPartial(from: stitcher, onPartial: onPartial)
                 case .failure(let message):
                     failedChunks += 1
@@ -153,8 +162,52 @@ public actor ChunkedUtterancePipeline {
             let result = await transcribeChunk(samples: chunk.samples)
             switch result {
             case .success(let text):
-                stitcher.append(index: chunk.index, text: text)
-                publishPartial(from: stitcher, onPartial: onPartial)
+                if chunk.isLast,
+                   !didRetryEmptyFinal,
+                   let retry = FinalChunkRecovery.emptyResultRetryPlan(
+                       chunk: chunk,
+                       previousChunkSamples: previousChunkSamples,
+                       config: config,
+                       asrText: text
+                   ) {
+                    didRetryEmptyFinal = true
+                    FlowPipelineDiagnostics.logFinalChunkRecovery(
+                        action: "emptyRetry",
+                        chunkIndex: chunk.index
+                    )
+                    let retryResult = await transcribeChunk(samples: retry.samples)
+                    switch retryResult {
+                    case .success(let retryText):
+                        let trimmed = retryText.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !trimmed.isEmpty {
+                            if retry.stitchIndex < chunk.index {
+                                stitcher.removeLastSegment()
+                            }
+                            stitcher.append(index: retry.stitchIndex, text: retryText)
+                            publishPartial(from: stitcher, onPartial: onPartial)
+                        } else {
+                            stitcher.append(index: chunk.index, text: text)
+                            publishPartial(from: stitcher, onPartial: onPartial)
+                        }
+                    case .failure(let message):
+                        stitcher.append(index: chunk.index, text: text)
+                        publishPartial(from: stitcher, onPartial: onPartial)
+                        failedChunks += 1
+                        chunkWarnings.append(
+                            SharedL10n.format(
+                                "error.asr.chunkFailed",
+                                chunk.index + 1,
+                                message
+                            )
+                        )
+                    case .cancelled:
+                        feeder.cancel()
+                        return .cancelled
+                    }
+                } else {
+                    stitcher.append(index: chunk.index, text: text)
+                    publishPartial(from: stitcher, onPartial: onPartial)
+                }
             case .failure(let message):
                 failedChunks += 1
                 chunkWarnings.append(

--- a/OSGKeyboardShared/Services/FlowContinuousCapture.swift
+++ b/OSGKeyboardShared/Services/FlowContinuousCapture.swift
@@ -666,16 +666,11 @@ public final class FlowContinuousCapture {
         gate.withLock { $0 = .draining }
         drainTracker.beginDrain()
 
-        var endedBySilence = false
-        while true {
-            let decision = drainTracker.shouldFinish(policy: policy)
-            if decision.finished {
-                endedBySilence = decision.endedBySilence
-                break
-            }
-            if Task.isCancelled { break }
-            try? await Task.sleep(nanoseconds: FlowCaptureConstants.drainPollIntervalNs)
-        }
+        let timing = await FlowUtteranceEndCoordinator.awaitTailCapture(
+            tracker: drainTracker,
+            policy: policy,
+            pollIntervalNs: FlowCaptureConstants.drainPollIntervalNs
+        )
 
         // NOTE: We intentionally do NOT signal `.endOfStream` to the shared
         // downsampling converter here. `AVAudioConverter` is stateful: once its
@@ -692,8 +687,9 @@ public final class FlowContinuousCapture {
         let tailSamples = tailSampleCounter.withLock { $0 }
         let report = FlowCaptureDrainReport(
             drainDurationSeconds: drainTracker.elapsedSeconds(),
-            endedBySilence: endedBySilence,
-            tailSampleCount: tailSamples
+            endedBySilence: timing.endedBySilence,
+            tailSampleCount: tailSamples,
+            postRollDurationSeconds: timing.postRollDurationSeconds
         )
         drainTracker.reset()
         tailSampleCounter.withLock { $0 = 0 }

--- a/OSGKeyboardShared/Services/FlowContinuousCapture.swift
+++ b/OSGKeyboardShared/Services/FlowContinuousCapture.swift
@@ -281,6 +281,9 @@ public final class FlowContinuousCapture {
     private let gate = OSAllocatedUnfairLock(initialState: UtteranceGatePhase.idle)
     private let drainTracker = FlowCaptureDrainTracker()
     private let tailSampleCounter = OSAllocatedUnfairLock(initialState: 0)
+    private let utterancePCMStore = FlowUtterancePCMStore(
+        maxSampleCount: Int(FlowSessionKeys.maxUtteranceDuration) * 16_000
+    )
 
     private var downsampler: AdaptiveDownsampler?
     private var targetFormat: AVAudioFormat?
@@ -412,6 +415,7 @@ public final class FlowContinuousCapture {
         let proof = audioProofStore
         let tracker = drainTracker
         let tailCounter = tailSampleCounter
+        let pcmStore = utterancePCMStore
         let policy = drainPolicy
         let tap = Self.makeAudioTapBlock(
             downsampler: downsampler,
@@ -422,6 +426,7 @@ public final class FlowContinuousCapture {
             streamRelay: relay,
             drainTracker: tracker,
             tailSampleCounter: tailCounter,
+            utterancePCMStore: pcmStore,
             drainPolicy: policy
         )
         // `format: nil` binds the tap to the input node's *live* format. Passing
@@ -645,6 +650,7 @@ public final class FlowContinuousCapture {
         let (stream, continuation) = AsyncStream<AudioBufferSnapshot>.makeStream()
         drainTracker.reset()
         tailSampleCounter.withLock { $0 = 0 }
+        utterancePCMStore.reset()
         // Bind the consumer before opening the gate so early tap frames
         // are not dropped on the floor.
         streamRelay.bind(continuation)
@@ -697,11 +703,17 @@ public final class FlowContinuousCapture {
         return report
     }
 
+    /// Returns the utterance PCM accumulated during the last recording cycle.
+    public func consumeUtteranceSamples() -> [Float] {
+        utterancePCMStore.consume()
+    }
+
     /// Immediate stop without tail drain (abort / session teardown).
     public func cancelUtterance() {
         gate.withLock { $0 = .idle }
         drainTracker.reset()
         tailSampleCounter.withLock { $0 = 0 }
+        utterancePCMStore.reset()
         streamRelay.finish()
     }
 
@@ -720,6 +732,7 @@ public final class FlowContinuousCapture {
         streamRelay: FlowCaptureStreamRelay,
         drainTracker: FlowCaptureDrainTracker,
         tailSampleCounter: OSAllocatedUnfairLock<Int>,
+        utterancePCMStore: FlowUtterancePCMStore,
         drainPolicy: FlowCaptureTailDrainPolicy
     ) -> @Sendable (AVAudioPCMBuffer, AVAudioTime) -> Void {
         return { buffer, _ in
@@ -739,6 +752,7 @@ public final class FlowContinuousCapture {
             let phase = gate.withLock { $0 }
             switch phase {
             case .recording, .draining:
+                utterancePCMStore.append(snapshot.samples)
                 streamRelay.yield(snapshot)
                 if phase == .draining {
                     drainTracker.noteAudio(samples: snapshot.samples, policy: drainPolicy)

--- a/OSGKeyboardShared/Services/LiveDictationController.swift
+++ b/OSGKeyboardShared/Services/LiveDictationController.swift
@@ -558,12 +558,10 @@ public final class LiveDictationController: ObservableObject {
         drainTracker.beginDrain()
 
         let policy = FlowCaptureTailDrainPolicy.flowDefault
-        while true {
-            let decision = drainTracker.shouldFinish(policy: policy)
-            if decision.finished { break }
-            if Task.isCancelled { break }
-            try? await Task.sleep(nanoseconds: 20_000_000)
-        }
+        _ = await FlowUtteranceEndCoordinator.awaitTailCapture(
+            tracker: drainTracker,
+            policy: policy
+        )
 
         // Trailing speech is preserved by the live `.draining` forwarding
         // loop above. We deliberately do NOT signal `.endOfStream` to the

--- a/OSGKeyboardShared/Utilities/FinalChunkRecovery.swift
+++ b/OSGKeyboardShared/Utilities/FinalChunkRecovery.swift
@@ -1,0 +1,47 @@
+// FinalChunkRecovery.swift
+// OSGKeyboard · Shared
+//
+// Recovery plans for pipelined utterance ASR when the final chunk is short,
+// empty, or straddles a chunk boundary.
+
+import Foundation
+
+public enum FinalChunkRecovery {
+
+    /// Samples and stitch index when the final chunk should be merged with
+    /// prior overlap *before* the first ASR pass.
+    public static func preMergePlan(
+        chunk: UtteranceAudioChunk,
+        processedChunks: Int,
+        previousChunkSamples: [Float],
+        config: FlowUtteranceChunkConfig
+    ) -> (samples: [Float], stitchIndex: Int)? {
+        guard chunk.isLast, !chunk.samples.isEmpty, !previousChunkSamples.isEmpty else {
+            return nil
+        }
+        guard chunk.samples.count < config.minFinalChunkSamples else { return nil }
+
+        let merged = Array(previousChunkSamples.suffix(config.overlapSamples)) + chunk.samples
+        return (merged, max(0, chunk.index - 1))
+    }
+
+    /// Retry plan when the final chunk had audio but ASR returned empty text.
+    public static func emptyResultRetryPlan(
+        chunk: UtteranceAudioChunk,
+        previousChunkSamples: [Float],
+        config: FlowUtteranceChunkConfig,
+        asrText: String
+    ) -> (samples: [Float], stitchIndex: Int)? {
+        guard chunk.isLast, !chunk.samples.isEmpty else { return nil }
+        guard asrText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+
+        if previousChunkSamples.isEmpty {
+            return (chunk.samples, chunk.index)
+        }
+
+        let merged = Array(previousChunkSamples.suffix(config.overlapSamples)) + chunk.samples
+        return (merged, max(0, chunk.index - 1))
+    }
+}

--- a/OSGKeyboardShared/Utilities/FlowCaptureTailDrain.swift
+++ b/OSGKeyboardShared/Utilities/FlowCaptureTailDrain.swift
@@ -16,22 +16,39 @@ public struct FlowCaptureTailDrainPolicy: Sendable, Equatable {
     public let silenceDurationSeconds: TimeInterval
     /// Hard cap so noisy environments cannot stall finalize forever.
     public let maxDrainSeconds: TimeInterval
+    /// Fixed post-roll after silence drain; independent of RMS (captures weak tails).
+    public let postRollSeconds: TimeInterval
 
     public init(
         silenceRMSThreshold: Float,
         silenceDurationSeconds: TimeInterval,
-        maxDrainSeconds: TimeInterval
+        maxDrainSeconds: TimeInterval,
+        postRollSeconds: TimeInterval = 0
     ) {
         self.silenceRMSThreshold = silenceRMSThreshold
         self.silenceDurationSeconds = silenceDurationSeconds
         self.maxDrainSeconds = maxDrainSeconds
+        self.postRollSeconds = postRollSeconds
     }
 
-    public static let flowDefault = FlowCaptureTailDrainPolicy(
+    /// iOS Flow host + keyboard utterance capture.
+    public static let iosFlow = FlowCaptureTailDrainPolicy(
         silenceRMSThreshold: 0.015,
-        silenceDurationSeconds: 0.25,
-        maxDrainSeconds: 1.5
+        silenceDurationSeconds: 0.35,
+        maxDrainSeconds: 1.5,
+        postRollSeconds: 0.15
     )
+
+    /// Mac MLX streaming live capture.
+    public static let macMLX = FlowCaptureTailDrainPolicy(
+        silenceRMSThreshold: 0.015,
+        silenceDurationSeconds: 0.35,
+        maxDrainSeconds: 0.75,
+        postRollSeconds: 0.15
+    )
+
+    /// Backward-compatible alias for iOS Flow defaults.
+    public static let flowDefault = iosFlow
 }
 
 /// Metrics emitted when tail drain completes (for diagnostics and tests).
@@ -39,21 +56,25 @@ public struct FlowCaptureDrainReport: Sendable, Equatable {
     public let drainDurationSeconds: Double
     public let endedBySilence: Bool
     public let tailSampleCount: Int
+    public let postRollDurationSeconds: Double
 
     public init(
         drainDurationSeconds: Double,
         endedBySilence: Bool,
-        tailSampleCount: Int
+        tailSampleCount: Int,
+        postRollDurationSeconds: Double = 0
     ) {
         self.drainDurationSeconds = drainDurationSeconds
         self.endedBySilence = endedBySilence
         self.tailSampleCount = tailSampleCount
+        self.postRollDurationSeconds = postRollDurationSeconds
     }
 
     public static let skipped = FlowCaptureDrainReport(
         drainDurationSeconds: 0,
         endedBySilence: false,
-        tailSampleCount: 0
+        tailSampleCount: 0,
+        postRollDurationSeconds: 0
     )
 }
 

--- a/OSGKeyboardShared/Utilities/FlowPipelineDiagnostics.swift
+++ b/OSGKeyboardShared/Utilities/FlowPipelineDiagnostics.swift
@@ -25,6 +25,18 @@ public enum FlowPipelineDiagnostics {
         OSGLog.asr.info("finalChunkRecovery \(action) chunk=\(chunkIndex)")
     }
 
+    public static func logBatchFallback(
+        sampleCount: Int,
+        stitchedLength: Int,
+        partialLength: Int,
+        batchLength: Int
+    ) {
+        OSGLog.flow.info(
+            "batchFallback samples=\(sampleCount) stitchedLen=\(stitchedLength) " +
+            "partialLen=\(partialLength) batchLen=\(batchLength)"
+        )
+    }
+
     public static func logChunkFinalize(
         chunkCount: Int,
         lastChunkSamples: Int,

--- a/OSGKeyboardShared/Utilities/FlowPipelineDiagnostics.swift
+++ b/OSGKeyboardShared/Utilities/FlowPipelineDiagnostics.swift
@@ -9,8 +9,20 @@ import os
 public enum FlowPipelineDiagnostics {
     public static func logDrain(_ report: FlowCaptureDrainReport) {
         OSGLog.flow.info(
-            "tailDrain duration=\(report.drainDurationSeconds, format: .fixed(precision: 2))s silenceEnd=\(report.endedBySilence) tailSamples=\(report.tailSampleCount)"
+            "tailDrain duration=\(report.drainDurationSeconds, format: .fixed(precision: 2))s " +
+            "postRoll=\(report.postRollDurationSeconds, format: .fixed(precision: 2))s " +
+            "silenceEnd=\(report.endedBySilence) tailSamples=\(report.tailSampleCount)"
         )
+    }
+
+    public static func logTranscriptGuardUsedPartial(finalLength: Int, partialLength: Int) {
+        OSGLog.flow.warning(
+            "transcriptGuard partial preferred finalLen=\(finalLength) partialLen=\(partialLength)"
+        )
+    }
+
+    public static func logFinalChunkRecovery(action: String, chunkIndex: Int) {
+        OSGLog.asr.info("finalChunkRecovery \(action) chunk=\(chunkIndex)")
     }
 
     public static func logChunkFinalize(

--- a/OSGKeyboardShared/Utilities/FlowUtteranceEndCoordinator.swift
+++ b/OSGKeyboardShared/Utilities/FlowUtteranceEndCoordinator.swift
@@ -1,0 +1,66 @@
+// FlowUtteranceEndCoordinator.swift
+// OSGKeyboard · Shared
+//
+// Unified tail-drain + post-roll orchestration after the user stops recording.
+// Keeps the mic gate open through silence detection, then a fixed post-roll
+// window that does not depend on RMS (captures weak trailing syllables).
+
+import Foundation
+
+/// Outcome of `FlowUtteranceEndCoordinator.awaitTailCapture`.
+public struct FlowUtteranceEndTiming: Sendable, Equatable {
+    public let endedBySilence: Bool
+    public let postRollDurationSeconds: Double
+
+    public init(endedBySilence: Bool, postRollDurationSeconds: Double) {
+        self.endedBySilence = endedBySilence
+        self.postRollDurationSeconds = postRollDurationSeconds
+    }
+}
+
+public enum FlowUtteranceEndCoordinator {
+    /// Poll interval while waiting for silence / max drain (20 ms).
+    public static let pollIntervalNs: UInt64 = 20_000_000
+
+    /// Waits until trailing speech drains (silence or max cap), then sleeps
+    /// through a fixed post-roll window so weak tail audio still reaches ASR.
+    ///
+    /// Callers must keep forwarding PCM from the audio tap while this runs
+    /// (gate `.draining` or equivalent).
+    public static func awaitTailCapture(
+        tracker: FlowCaptureDrainTracker,
+        policy: FlowCaptureTailDrainPolicy,
+        pollIntervalNs: UInt64 = pollIntervalNs
+    ) async -> FlowUtteranceEndTiming {
+        var endedBySilence = false
+        while true {
+            let decision = tracker.shouldFinish(policy: policy)
+            if decision.finished {
+                endedBySilence = decision.endedBySilence
+                break
+            }
+            if Task.isCancelled { break }
+            try? await Task.sleep(nanoseconds: pollIntervalNs)
+        }
+
+        let postRoll = await runPostRoll(policy: policy, pollIntervalNs: pollIntervalNs)
+        return FlowUtteranceEndTiming(
+            endedBySilence: endedBySilence,
+            postRollDurationSeconds: postRoll
+        )
+    }
+
+    private static func runPostRoll(
+        policy: FlowCaptureTailDrainPolicy,
+        pollIntervalNs: UInt64
+    ) async -> Double {
+        guard policy.postRollSeconds > 0 else { return 0 }
+        let started = Date()
+        let deadline = started.addingTimeInterval(policy.postRollSeconds)
+        while Date() < deadline {
+            if Task.isCancelled { break }
+            try? await Task.sleep(nanoseconds: pollIntervalNs)
+        }
+        return max(0, Date().timeIntervalSince(started))
+    }
+}

--- a/OSGKeyboardShared/Utilities/FlowUtterancePCMStore.swift
+++ b/OSGKeyboardShared/Utilities/FlowUtterancePCMStore.swift
@@ -1,0 +1,46 @@
+// FlowUtterancePCMStore.swift
+// OSGKeyboard · Shared
+//
+// Thread-safe rolling buffer of 16 kHz mono utterance PCM for whole-utterance
+// batch ASR fallback when pipelined chunking drops weak tail segments.
+
+import Foundation
+
+public final class FlowUtterancePCMStore: @unchecked Sendable {
+    private let lock = OSAllocatedUnfairLock()
+    private var samples: [Float] = []
+    private let maxSampleCount: Int
+
+    public init(maxSampleCount: Int) {
+        self.maxSampleCount = max(1, maxSampleCount)
+    }
+
+    public func reset() {
+        lock.withLock {
+            samples.removeAll(keepingCapacity: false)
+        }
+    }
+
+    public func append(_ chunk: [Float]) {
+        guard !chunk.isEmpty else { return }
+        lock.withLock {
+            samples.append(contentsOf: chunk)
+            if samples.count > maxSampleCount {
+                samples.removeFirst(samples.count - maxSampleCount)
+            }
+        }
+    }
+
+    public var sampleCount: Int {
+        lock.withLock { samples.count }
+    }
+
+    /// Returns accumulated samples and clears the store.
+    public func consume() -> [Float] {
+        lock.withLock {
+            let out = samples
+            samples.removeAll(keepingCapacity: false)
+            return out
+        }
+    }
+}

--- a/OSGKeyboardShared/Utilities/UtteranceBatchFallbackPolicy.swift
+++ b/OSGKeyboardShared/Utilities/UtteranceBatchFallbackPolicy.swift
@@ -1,0 +1,41 @@
+// UtteranceBatchFallbackPolicy.swift
+// OSGKeyboard · Shared
+//
+// Decides when to re-run ASR on the full utterance PCM after pipelined
+// chunking, and how to pick the best transcript among candidates.
+
+import Foundation
+
+public enum UtteranceBatchFallbackPolicy {
+    public static let defaultCharacterAdvantage = UtteranceTranscriptGuard.defaultPartialAdvantage
+
+    /// True when chunked output likely lost trailing content vs the live partial.
+    public static func shouldRunBatchFallback(
+        stitchedFinal: String,
+        partialSnapshot: String,
+        minimumCharacterAdvantage: Int = defaultCharacterAdvantage
+    ) -> Bool {
+        let final = stitchedFinal.trimmingCharacters(in: .whitespacesAndNewlines)
+        let partial = partialSnapshot.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if final.isEmpty, !partial.isEmpty { return true }
+        if partial.isEmpty { return false }
+        return partial.count >= final.count + minimumCharacterAdvantage
+    }
+
+    /// Prefer the longest non-empty transcript after batch ASR completes.
+    public static func preferredTranscript(
+        batch: String,
+        stitchedFinal: String,
+        partialSnapshot: String,
+        current: String
+    ) -> String {
+        let candidates = [batch, current, stitchedFinal, partialSnapshot]
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        guard let best = candidates.max(by: { $0.count < $1.count }) else {
+            return current.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return best
+    }
+}

--- a/OSGKeyboardShared/Utilities/UtteranceStreamChunker.swift
+++ b/OSGKeyboardShared/Utilities/UtteranceStreamChunker.swift
@@ -56,7 +56,11 @@ public enum UtteranceStreamChunker {
                 } else if chunkIndex == 0 {
                     // Empty utterance — no chunks.
                 } else {
-                    // Stream ended exactly on boundary; mark prior path complete.
+                    // Stream ended exactly on a chunk boundary; prior emit holds
+                    // all tail audio. Marker so FinalChunkRecovery paths run.
+                    continuation.yield(
+                        UtteranceAudioChunk(index: chunkIndex, samples: [], isLast: true)
+                    )
                 }
 
                 continuation.finish()

--- a/OSGKeyboardShared/Utilities/UtteranceTranscriptGuard.swift
+++ b/OSGKeyboardShared/Utilities/UtteranceTranscriptGuard.swift
@@ -1,0 +1,35 @@
+// UtteranceTranscriptGuard.swift
+// OSGKeyboard · Shared
+//
+// Chooses the best available transcript when pipelined final text may have
+// dropped a weak tail segment.
+
+import Foundation
+
+public enum UtteranceTranscriptGuard {
+    /// Partial must exceed final by at least this many characters to win.
+    public static let defaultPartialAdvantage = 8
+
+    /// Prefer `stitchedFinal` unless empty or clearly shorter than the live
+    /// partial snapshot taken at mic stop.
+    public static func resolve(
+        stitchedFinal: String,
+        partialSnapshot: String,
+        minimumPartialAdvantage: Int = defaultPartialAdvantage
+    ) -> String {
+        let final = stitchedFinal.trimmingCharacters(in: .whitespacesAndNewlines)
+        let partial = partialSnapshot.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if final.isEmpty { return partial }
+        if partial.isEmpty { return final }
+
+        if partial.count >= final.count + minimumPartialAdvantage {
+            FlowPipelineDiagnostics.logTranscriptGuardUsedPartial(
+                finalLength: final.count,
+                partialLength: partial.count
+            )
+            return partial
+        }
+        return final
+    }
+}

--- a/OSGKeyboardTests/ChunkedUtterancePipelineTests.swift
+++ b/OSGKeyboardTests/ChunkedUtterancePipelineTests.swift
@@ -115,6 +115,34 @@ final class ChunkedUtterancePipelineTests: XCTestCase {
         }
         XCTAssertTrue(success.text.contains("merged"))
     }
+
+    func testPipelineRetriesEmptyFinalChunkWithOverlap() async {
+        let config = FlowUtteranceChunkConfig(
+            maxChunkDurationSeconds: 0.05,
+            overlapDurationSeconds: 10,
+            pauseExtensionMaxSeconds: 0,
+            pauseRMSThreshold: 0.02,
+            minFinalChunkDurationSeconds: 0.05,
+            sampleRate: 1_000
+        )
+        let asr = EmptyFinalRetryStubASR()
+        let pipeline = ChunkedUtterancePipeline(
+            asr: asr,
+            locale: Locale(identifier: "zh-Hans"),
+            config: config
+        )
+
+        let (stream, continuation) = AsyncStream<AudioBufferSnapshot>.makeStream()
+        continuation.yield(AudioBufferSnapshot(samples: [Float](repeating: 0.1, count: 80), sampleRate: 1_000))
+        continuation.yield(AudioBufferSnapshot(samples: [Float](repeating: 0.1, count: 80), sampleRate: 1_000))
+        continuation.finish()
+
+        let outcome = await pipeline.transcribe(stream: stream) { _ in }
+        guard case .success(let success) = outcome else {
+            return XCTFail("expected success, got \(outcome)")
+        }
+        XCTAssertTrue(success.text.contains("recovered-tail"))
+    }
 }
 
 private struct FailingSecondChunkASR: ASRService, @unchecked Sendable {
@@ -169,5 +197,34 @@ private struct ShortFinalMergeStubASR: ASRService, @unchecked Sendable {
             return .success("merged-tail")
         }
         return .success("short")
+    }
+}
+
+private struct EmptyFinalRetryStubASR: ASRService, @unchecked Sendable {
+    private let callIndex = OSAllocatedUnfairLock(initialState: 0)
+
+    func transcribe(
+        stream: AsyncStream<AudioBufferSnapshot>,
+        locale: Locale
+    ) -> AsyncStream<ASREvent> {
+        AsyncStream { $0.finish() }
+    }
+
+    func cancel() {}
+
+    func transcribeChunk(samples: [Float], locale: Locale) async -> ASRChunkResult {
+        _ = locale
+        let current = callIndex.withLock { state in
+            let value = state
+            state += 1
+            return value
+        }
+        if current == 0 {
+            return .success("head")
+        }
+        if current == 1 {
+            return .success("")
+        }
+        return .success("recovered-tail")
     }
 }

--- a/OSGKeyboardTests/FinalChunkRecoveryTests.swift
+++ b/OSGKeyboardTests/FinalChunkRecoveryTests.swift
@@ -1,0 +1,74 @@
+// FinalChunkRecoveryTests.swift
+// OSGKeyboardTests
+
+import XCTest
+@testable import OSGKeyboardShared
+
+final class FinalChunkRecoveryTests: XCTestCase {
+
+    private let config = FlowUtteranceChunkConfig(
+        maxChunkDurationSeconds: 5.0,
+        overlapDurationSeconds: 0.5,
+        pauseExtensionMaxSeconds: 2,
+        pauseRMSThreshold: 0.015,
+        minFinalChunkDurationSeconds: 0.8,
+        sampleRate: 16_000
+    )
+
+    func testPreMergePlanForShortFinalChunk() {
+        let chunk = UtteranceAudioChunk(
+            index: 1,
+            samples: [Float](repeating: 0.1, count: 4_000),
+            isLast: true
+        )
+        let previous = [Float](repeating: 0.2, count: 80_000)
+
+        let plan = FinalChunkRecovery.preMergePlan(
+            chunk: chunk,
+            processedChunks: 2,
+            previousChunkSamples: previous,
+            config: config
+        )
+
+        XCTAssertNotNil(plan)
+        XCTAssertGreaterThan(plan?.samples.count ?? 0, chunk.samples.count)
+        XCTAssertEqual(plan?.stitchIndex, 0)
+    }
+
+    func testEmptyResultRetryPlanUsesOverlapWhenPriorChunkExists() {
+        let chunk = UtteranceAudioChunk(
+            index: 1,
+            samples: [Float](repeating: 0.1, count: 20_000),
+            isLast: true
+        )
+        let previous = [Float](repeating: 0.2, count: 80_000)
+
+        let plan = FinalChunkRecovery.emptyResultRetryPlan(
+            chunk: chunk,
+            previousChunkSamples: previous,
+            config: config,
+            asrText: "  "
+        )
+
+        XCTAssertNotNil(plan)
+        XCTAssertGreaterThan(plan?.samples.count ?? 0, chunk.samples.count)
+    }
+
+    func testEmptyResultRetryPlanRetriesSingleChunkSamples() {
+        let chunk = UtteranceAudioChunk(
+            index: 0,
+            samples: [Float](repeating: 0.1, count: 20_000),
+            isLast: true
+        )
+
+        let plan = FinalChunkRecovery.emptyResultRetryPlan(
+            chunk: chunk,
+            previousChunkSamples: [],
+            config: config,
+            asrText: ""
+        )
+
+        XCTAssertEqual(plan?.samples.count, chunk.samples.count)
+        XCTAssertEqual(plan?.stitchIndex, 0)
+    }
+}

--- a/OSGKeyboardTests/FlowUtteranceEndCoordinatorTests.swift
+++ b/OSGKeyboardTests/FlowUtteranceEndCoordinatorTests.swift
@@ -1,0 +1,35 @@
+// FlowUtteranceEndCoordinatorTests.swift
+// OSGKeyboardTests
+
+import XCTest
+@testable import OSGKeyboardShared
+
+final class FlowUtteranceEndCoordinatorTests: XCTestCase {
+
+    func testAwaitTailCaptureRunsPostRollAfterSilenceDrain() async {
+        let policy = FlowCaptureTailDrainPolicy(
+            silenceRMSThreshold: 0.02,
+            silenceDurationSeconds: 0.05,
+            maxDrainSeconds: 1.0,
+            postRollSeconds: 0.08
+        )
+        let tracker = FlowCaptureDrainTracker()
+        let start = Date().timeIntervalSince1970
+        tracker.beginDrain(now: start)
+
+        let timing = await FlowUtteranceEndCoordinator.awaitTailCapture(
+            tracker: tracker,
+            policy: policy,
+            pollIntervalNs: 5_000_000
+        )
+
+        XCTAssertTrue(timing.endedBySilence)
+        XCTAssertGreaterThanOrEqual(timing.postRollDurationSeconds, 0.07)
+    }
+
+    func testIOSFlowPresetUsesLongerSilenceAndPostRoll() {
+        XCTAssertEqual(FlowCaptureTailDrainPolicy.iosFlow.silenceDurationSeconds, 0.35)
+        XCTAssertEqual(FlowCaptureTailDrainPolicy.iosFlow.postRollSeconds, 0.15)
+        XCTAssertEqual(FlowCaptureTailDrainPolicy.flowDefault, FlowCaptureTailDrainPolicy.iosFlow)
+    }
+}

--- a/OSGKeyboardTests/FlowUtterancePCMStoreTests.swift
+++ b/OSGKeyboardTests/FlowUtterancePCMStoreTests.swift
@@ -1,0 +1,23 @@
+// FlowUtterancePCMStoreTests.swift
+// OSGKeyboardTests
+
+import XCTest
+@testable import OSGKeyboardShared
+
+final class FlowUtterancePCMStoreTests: XCTestCase {
+
+    func testAppendAndConsume() {
+        let store = FlowUtterancePCMStore(maxSampleCount: 100)
+        store.append([1, 2, 3])
+        store.append([4, 5])
+        XCTAssertEqual(store.sampleCount, 5)
+        XCTAssertEqual(store.consume(), [1, 2, 3, 4, 5])
+        XCTAssertEqual(store.sampleCount, 0)
+    }
+
+    func testTrimsOldestWhenOverCap() {
+        let store = FlowUtterancePCMStore(maxSampleCount: 4)
+        store.append([1, 2, 3, 4, 5])
+        XCTAssertEqual(store.consume(), [2, 3, 4, 5])
+    }
+}

--- a/OSGKeyboardTests/UtteranceBatchFallbackPolicyTests.swift
+++ b/OSGKeyboardTests/UtteranceBatchFallbackPolicyTests.swift
@@ -1,0 +1,45 @@
+// UtteranceBatchFallbackPolicyTests.swift
+// OSGKeyboardTests
+
+import XCTest
+@testable import OSGKeyboardShared
+
+final class UtteranceBatchFallbackPolicyTests: XCTestCase {
+
+    func testShouldRunWhenPartialClearlyLonger() {
+        XCTAssertTrue(
+            UtteranceBatchFallbackPolicy.shouldRunBatchFallback(
+                stitchedFinal: "今天很好",
+                partialSnapshot: "今天很好，我们一起去公园吧"
+            )
+        )
+    }
+
+    func testShouldRunWhenFinalEmptyButPartialPresent() {
+        XCTAssertTrue(
+            UtteranceBatchFallbackPolicy.shouldRunBatchFallback(
+                stitchedFinal: "",
+                partialSnapshot: "最后一段"
+            )
+        )
+    }
+
+    func testShouldNotRunWhenPartialNotLonger() {
+        XCTAssertFalse(
+            UtteranceBatchFallbackPolicy.shouldRunBatchFallback(
+                stitchedFinal: "今天很好，我们一起去公园吧",
+                partialSnapshot: "今天很好"
+            )
+        )
+    }
+
+    func testPreferredTranscriptPicksLongestCandidate() {
+        let resolved = UtteranceBatchFallbackPolicy.preferredTranscript(
+            batch: "今天很好，我们一起去公园吧",
+            stitchedFinal: "今天很好",
+            partialSnapshot: "今天很好，我们",
+            current: "今天很好，我们"
+        )
+        XCTAssertEqual(resolved, "今天很好，我们一起去公园吧")
+    }
+}

--- a/OSGKeyboardTests/UtteranceTranscriptGuardTests.swift
+++ b/OSGKeyboardTests/UtteranceTranscriptGuardTests.swift
@@ -1,0 +1,32 @@
+// UtteranceTranscriptGuardTests.swift
+// OSGKeyboardTests
+
+import XCTest
+@testable import OSGKeyboardShared
+
+final class UtteranceTranscriptGuardTests: XCTestCase {
+
+    func testResolvePrefersPartialWhenClearlyLonger() {
+        let resolved = UtteranceTranscriptGuard.resolve(
+            stitchedFinal: "今天天气很好",
+            partialSnapshot: "今天天气很好，我们一起去公园吧"
+        )
+        XCTAssertEqual(resolved, "今天天气很好，我们一起去公园吧")
+    }
+
+    func testResolveKeepsFinalWhenPartialIsNotLonger() {
+        let resolved = UtteranceTranscriptGuard.resolve(
+            stitchedFinal: "今天天气很好，我们一起去公园吧",
+            partialSnapshot: "今天天气很好"
+        )
+        XCTAssertEqual(resolved, "今天天气很好，我们一起去公园吧")
+    }
+
+    func testResolveUsesPartialWhenFinalEmpty() {
+        let resolved = UtteranceTranscriptGuard.resolve(
+            stitchedFinal: "",
+            partialSnapshot: "最后一段 partial"
+        )
+        XCTAssertEqual(resolved, "最后一段 partial")
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the recurring issue where the last segment of a Flow dictation utterance was missing from ASR output. The root cause was a combination of early tail stream closure (weak trailing syllables) and insufficient final-chunk ASR fallback.

## Changes (P0)

### Tail capture (Shared)
- **`FlowUtteranceEndCoordinator`**: unified silence drain + fixed post-roll orchestration
- **`FlowCaptureTailDrainPolicy`**: new presets `iosFlow` / `macMLX`; iOS silence window 250ms → **350ms**; added **150ms post-roll** independent of RMS
- Integrated into `FlowContinuousCapture` and `LiveDictationController`

### Final chunk ASR recovery (Shared)
- **`FinalChunkRecovery`**: pre-merge for short final chunks; empty-result retry with prior overlap
- **`ChunkedUtterancePipeline`**: uses recovery paths; skips empty boundary marker chunks
- **`UtteranceStreamChunker`**: emits `isLast` marker when stream ends on chunk boundary

### Transcript fallback (Host)
- **`UtteranceTranscriptGuard`**: prefer live partial snapshot when clearly longer than stitched final
- **`FlowSessionManager`**: snapshots partial at mic stop; applies guard during finalize

### Diagnostics & tests
- Extended drain/final-chunk logging
- Unit tests for coordinator, recovery, guard, and empty-final retry pipeline

## What we kept (not replaced)
- Chunked pipelined ASR architecture
- Gate idle/recording/draining phases
- Session-long converter no-EOS invariant
- `cancelUtterance` fast path without drain
- `UtteranceTranscriptStitcher.composedSafely()`

## Testing
- [ ] macOS: `xcodebuild test` — new Shared unit tests
- [ ] Device: short utterances with soft trailing syllables (的/了/吗)
- [ ] Device: multi-chunk long utterances — verify tail words appear

## Follow-up (P1, not in this PR)
- Whole-utterance batch fallback on iOS when final ≪ partial
- Mac MLX inline drain loop → shared coordinator
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9d96-9e3a-793b-a2cf-724119a21570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9d96-9e3a-793b-a2cf-724119a21570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

